### PR TITLE
requirements/s3: Add initial requirements for s3

### DIFF
--- a/requirements/s3/01-System-Instance.md
+++ b/requirements/s3/01-System-Instance.md
@@ -1,0 +1,53 @@
+## Section 1. System Instance Use Cases
+
+* 1.1: **System Instance Bootstrap** \
+  System instance is "launched" via standard system startup tools.
+  - Implementation: \
+  System instance brokers are started automatically by systemd or other system
+  initialization and read configuration from static config files to aid in
+  wireup. This system instance can tolerate disjoint startup and "resources"
+  or ranks are noted as "down" by the instance until they join the comms
+  session.
+
+* 1.2: **System Instance Resource Configuration** \
+  System instance reads schedulable resource information from a configuration
+  file. Only resources so configured may be scheduled to jobs.
+  - Implementation: \
+  Use GraphML in the case of flux-sched resource service or simplified
+  RDL+hwloc if using only lightweight flux-core testing scheduler.
+
+* 1.3: **System Instance Default Connector** \
+  A Flux command executed on a system with a system instance will by default
+  use a connector to the system instance.
+  - Implementation: \
+  If no `FLUX_URI` set in environment, `flux`(1) command uses default system
+  configuration (from `/etc/flux/conf.d/*.toml`?) to open standard default
+  connector and URI.
+
+* 1.4:  **KVS Resiliency** \
+  KVS is resilent to loss of brokers hold master KVS data.
+  - Implementation: \
+  KVS will store and state save of last known good root hash, recoverable from
+  a known location in case of restart/reboot of comms session and/or rank 0
+  broker.
+
+* 1.4: **Communications Resiliency** \
+  The Flux system instance will be resilient to the loss of nodes or brokers
+  internal to the comms network.
+  - Implementation: \
+  Flux comms network will transition to BGN or other network type with
+  redundancy that allows loss of abitrary numbers of internal network nodes.
+
+* 1.5: **Service Resiliency** \
+  Important Flux services do not lose data when nodes/brokers are lost.
+  - Implementation: \ 
+  Services leverage KVS resiliency for important data (checkpoints), and
+  similarly leverage network resiliency to remain available after internal
+  node/broker loss.
+
+* 1.6: **System Instance Broker Monitoring** \
+  System instance will monitor and report broker ranks going up/down and
+  generate events and liveness status query capability.
+  - Implementation: :warning: \
+  TBD
+

--- a/requirements/s3/02-Scheduler.md
+++ b/requirements/s3/02-Scheduler.md
@@ -1,0 +1,69 @@
+## Section 2. Scheduler Use Cases
+
+* 2.1: **Simple Job Submission** \
+  Flux-supports simple job submission requesting only a number of cores,
+  via `flux submit` or `flux run`.
+  - Implementation: \
+  `flux submit --cores=N` or `flux run --cores=N` create a simple jobspec
+  with a flat request for a number of cores. That request is signed and
+  sent along as job request.
+
+* 2.2: **FIFO Scheduler** \
+  Flux-scheduler will allocate jobs in first-in order.
+  - Implementation: \
+  TBD
+
+* 2.3: **Interactive Jobs** \
+  Interactive jobs will be submitted directly to an instance by selecting
+  an "interactive" job class (name TDB?). This will be the default for
+  `flux run`, with `flux submit` the class may be selected with a cmdline
+  option.
+  - Implementation: \
+   Requested job class is denoted in a jobspec field. The default field
+   value will place the job into the normal scheduling queue, but a
+   setting of "interactive" (or other suitable name) will place the job
+   into a queue that is optimized to reduce to queue wait-time by applying
+   other constraints (smaller max core counts, reduced runtime). The scheduler
+   may need to hold resources in reserve for interactive queues. The amount
+   Needs slightly more design.
+
+* 2.4: **Job Feasibility** \
+  Jobs submitted that cannot run under the current configuration will
+  be rejected during submission with an illustrative error message.
+  - Implementation: \
+   Job Feasibility checks are completed by a job ingest plugin or set of
+   plugins that check various parameters and reject the job if those
+   parameters do not satisfy feasibility. The flux error message returned
+   to the user should have a space for a detailed reason string or
+   message that can be printed by the job submission utility (not just
+   an error number)
+
+* 2.5: **List Jobs** \
+  Scheduler should offer a service to return a list of queue-ordered jobs
+  to any valid user.
+  - Implementation: \
+    TBD.
+
+* 2.6: **Job Query Interface** \
+  Job metadata availably only to instance scheduler should be available via
+  a query interface. Some data about the job should be redacted in the case
+  of a query from a user that is not also the owner of the job or have the
+  admin role.
+  - Implementation: \
+    A generic "job" service or similar handles query calls on behalf of
+    scheduler, and pulls relevant info from sched metadata in KVS (?)
+
+* 2.7: **Job Cancellation** \
+  A `flux job cancel` command should be offered to remove jobs from the
+  queue. If the job is running, it would be terminated.
+  - Implementation: \
+    A generic "job" service or similar handles cancellation? Scheduler
+    gets notified of cancellations in order to update queue.
+
+* 2.8: **Job Modification** \
+  Modification of some job parameters _may_ be allowed. There should
+  be an interface for this, and a mechanism should be explored during S3
+  timeframe, but perhaps this could be limited to timelimits or other
+  example metadata just as proof-of-concept for S3.
+  - Implementation: \
+    Unknown. May require ability to modify or amend signed jobspec in KVS.

--- a/requirements/s3/03-Resource-Services.md
+++ b/requirements/s3/03-Resource-Services.md
@@ -1,0 +1,41 @@
+## Section 3. Resource Services Use Cases
+
+* 3.1: **Resource up/down status** \
+  Configured resources are marked unavailable until they are known usable
+  for a job.
+  - Implementation: \
+  Sets of resources are associated with each broker rank (that rank being
+  the broker which will be capable of executing work on the resource set).
+  Resources within the set assigned to a broker will be marked as
+  down/unavailable until the broker is registered as live by broker monitoring
+  (1.6)
+
+* 3.2: **Withdraw Resource from Service** \
+  An alternate state to "down" is provided to withdraw a resource or set
+  of resources from being available for scheduling. Traditionally this
+  is called the "drain" state or flag. The drain state can exist at the
+  same time as any other state, and it is preserved until cleared. Withdrawing
+  a reasource should also affect all of its children.
+  - Implementation: \
+  :warning: TDB.
+ 
+
+* 3.3: **Resource Status Tool** \
+  A resource query tool to summarize state of resource types in a Flux
+  instance, e.g.:
+  ```
+  $ flux resource status "node"
+  Node:
+  total: 16
+  up: 16
+  down: 0
+  drained: 0
+  inuse: 0
+  ```
+  - Implementation: \
+  An interface to query total resources in a given state will be offered
+  by the system. Supported states will include configured, up, down, 
+  drained, and in-use/allocated. One or all states should be able to be 
+  queried in a single request. This query can be used to create the
+  `flux resource status` tool.
+

--- a/requirements/s3/04-Execution.md
+++ b/requirements/s3/04-Execution.md
@@ -1,0 +1,77 @@
+## Section 4. Execution Use Cases
+
+* 4.1: **Interactive Parallel Job** \
+  An "interactive" parallel job is an execution of `flux run` in which the
+  `flux run` (or shell frontend process) stays resident and does not terminate
+  until all tasks of the parallel job have exited and IO has completed.
+
+* 4.2: **Background Parallel Job** \
+  A background parallel job is a parallel job with no front end process,
+  e.g. `flux run` resident during execution. I/O, exit status and state
+  are streamed to the KVS, and events generated during major state
+  transitions.
+  
+
+* 4.3: **Batch Execution** \
+  A "batch job" is a script run under the identity of the batch user with
+  access to a resource set within the system. A batch job allows parallel
+  jobs to be executed on the resource set by one or more individual `flux run`
+  invocations from within the batch script. When the script ends the batch
+  job will be considered complete.
+  - Implementation: \ 
+    In Flux a batch job is a _background_ parallel job running an Flux instance,
+    with the batch script as the initial program of this instance. A tool
+    to submit batch jobs, e.g. `flux submit` should therefore take a
+    script argument along with other options and create a jobspec that
+    results in running one copy of `flux start` on every node of the
+    granted resource set, with a copy of the batch script as the argument
+    to `flux start`.
+
+* 4.4: **Interactive Job with No Arguments** \
+  In a batch script environment, `flux run COMMAND` with no extra resource
+  arguments should start with a copy of the jobspec that created the
+  enclosing instance. This implements standard practice in Slurm and possibly
+  other batch script environments, where default arguments to `srun` are
+  set by the batch script environment. This also allows a single batch script
+  to be used under different allocated resource set configurations.
+  - Implementation: \
+    Simplest approach is for `flux run` to default to a jobspec which
+    requests allocation of all extant resources in the current instance.
+    (We may want a shorthand jobspec stanza for this.) In Flux however,
+    at least the "task slot shape" will be a required argument. To get
+    around this, there would need to be a default task slot specification
+    that can be passed down to a sub-instance (which doesn't affect the
+    task slot of "Node" for the instance itself).
+
+* 4.5: **I/O To and From Files** \
+   `flux run` supports sending stderr/stdout to files in addition to
+    KVS, and supports redirecting stdin to one or more tasks from a file.
+    Default: broadcast stdin to all tasks, stderr/out copied to frontend
+    stderr/out or simply held in KVS for background job.
+
+* 4.6: **Process co-location** \
+   `flux run` should have a mode to launch work on existing resources
+   owned by the requesting user, without submission to a job queue. One
+   use case here is co-locating debugger processes or other tools with
+   one task per node or one task per existing task. Processes of the
+   co-located job will need to be run within the same namespace as the
+   targeted job.
+   - Implementation: :warning: \
+    TBD. It would be convenient if co-located jobs could reuse the same
+    KVS namespace as the running job, leveraging existing job shell(s) to
+    launch multiple parallel programs. The co-located program should be
+    able to be managed as its own parallel execution however, and ehancing
+    job shell to manage multiple parallel jobs at once may not be as
+    elegant as invoking another job shell which can enter namespace of
+    the exising job. In either case, KVS job schema may need to either
+    be reworked to allow multiple jobs to be managed per namespace, or
+    to allow copying(?) of an existing namespace.
+    
+* 4.7: **Administrative Execution** \
+  Users with "admin" role should be able to execute `flux run` or other
+  similar tool without scheduler involvement.
+  - Implementation: \
+    Admin users will need to have access to create KVS namespace for
+    jobs on the fly, with arbitrary R. Then `flux run` works as normal.
+    A range of job identifiers could be reserved for these jobs.
+    Another approach would be to stick to `flux exec` for this purpose.

--- a/requirements/s3/05-User-Management.md
+++ b/requirements/s3/05-User-Management.md
@@ -1,0 +1,21 @@
+## Section 5. User Management Use Cases
+
+* 5.1: **Unix Users** \
+  The system Flux instance will support only users in local password file
+  of the cluster on which it is run. Users added will be able to immediately
+  submit work to the instance and run jobs.
+  - Implementation: \
+    System instance userdb will initialize users from `/etc/passwd` file on
+    startup. The active user service on one rank will watch the passwd file
+    and  add/remove users in userdb as they appear and disappear.
+
+* 5.2: **Administrative users** \
+  Administrative users may have extra permissions within the instance, such
+  as direct access to the KVS or ability to adjust scheduler priority, etc.
+  These users are denoted by an "admin" user role in the userdb. For the
+  purposes of S3, this role should be automatically applied via configuration.
+  - Implementation: \
+    Configuration of system instance should be able to denote list of user
+    names with admin role (e.g. `user.admins = [ ... ]`) or add admin role
+    to all users in a given group (e.g. `user.admin-groups = [ "staff" ]`).
+

--- a/requirements/s3/README.md
+++ b/requirements/s3/README.md
@@ -1,0 +1,29 @@
+# S3 Milestone: Informal Requirements and Use Cases
+
+As an early delivery milestone for the Flux project, we propose a lightweight version of a Slurm replacement, which is suitable to function as a multi-user, system-level resource manager for a test cluster. The S3 version Flux will have the following high-level functionality, which is further detailed in the informal requirements and use cases of the pages below:
+
+ * Multi-user
+ * FIFO node/core only scheduler
+ * System instance with limited resiliency (single node failover)
+ * Static configuration
+
+Specifically, the following requirements are culled from S4 for S3 Flux:
+
+ * Preemption
+ * Standy jobs
+ * Scheduler "reason for not running"
+ * Email notification
+ * Job requeue
+ * Accounting DB
+ * Fairshare hierarchy
+ * Partition, Association, and "QoS" limits
+ * Job dependencies
+ * Other job request parameters outside of number of cores
+
+# Requirements and Use Cases
+
+ * **S3-1** [System Instance](01-System-Instance.md)
+ * **S3-2** [Scheduler](02-Scheduler.md)
+ * **S3-3** [Resource Services](03-Resource-Services.md)
+ * **S3-4** [Execution System](04-Execution.md)
+ * **S3-5** [User Management](05-User-Management.md)


### PR DESCRIPTION
This PR copies documentation from the flux-framework/distribution wiki to this new "planning" repository under flux-framwework.

The main benefit of moving planning documentation here is that changes can operate under the 
[C4.1 Fork/Pull Model](https://github.com/flux-framework/rfc/blob/master/spec_1.adoc), and changes can have easier review with public discussion. If this doesn't work out, it is low effort to move back to the wiki.

The documents I'm committing here can be considered early drafts are not meant to be complete.